### PR TITLE
Added subprotocol specification and Conn as a parameter in events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ evtwebsocket provides an extremely easy way of dealing with websocket connection
 ```go
 conn = evtwebsocket.Conn{
     // Fires when the connection is established
-    OnConnected: func(ws *websocket.Conn) {
+    OnConnected: func(w *evtwebsocket.Conn) {
         fmt.Println("Connected!")   
     },
     // Fires when a new message arrives from the server
-    OnMessage: func(msg []byte) {
+    OnMessage: func(msg []byte, w *evtwebsocket.Conn) {
         fmt.Printf("New message: %s\n", msg)   
     },
     // Fires when an error occurs and connection is closed
@@ -28,7 +28,7 @@ conn = evtwebsocket.Conn{
     PingMsg: []byte("PING"),
 }
 
-err := conn.Dial("https://example.com/ws")
+err := conn.Dial("https://example.com/ws", "")
 if err != nil {
     log.Fatal(err)
 }

--- a/evtwebsocket.go
+++ b/evtwebsocket.go
@@ -18,6 +18,7 @@ type Conn struct {
 	PingIntervalSecs int
 	ws               *websocket.Conn
 	url              string
+	subprotocol      string
 	closed           bool
 	msgQueue         []Msg
 	pingTimer        time.Time
@@ -36,6 +37,7 @@ type Msg struct {
 func (c *Conn) Dial(url, subprotocol string) error {
 	c.closed = true
 	c.url = url
+	c.subprotocol = subprotocol
 	c.msgQueue = []Msg{}
 	var err error
 	c.ws, err = websocket.Dial(url, subprotocol, "http://localhost/")
@@ -112,7 +114,7 @@ func (c *Conn) close() {
 	c.closed = true
 	if c.Reconnect {
 		for {
-			if err := c.Dial(c.url, ""); err == nil {
+			if err := c.Dial(c.url, c.subprotocol); err == nil {
 				break
 			}
 			time.Sleep(time.Second * 1)

--- a/evtwebsocket.go
+++ b/evtwebsocket.go
@@ -9,9 +9,9 @@ import (
 
 // Conn is the connection structure.
 type Conn struct {
-	OnMessage        func([]byte)
+	OnMessage        func([]byte, Conn)
 	OnError          func(error)
-	OnConnected      func(*websocket.Conn)
+	OnConnected      func(Conn)
 	MatchMsg         func([]byte, []byte) bool
 	Reconnect        bool
 	PingMsg          []byte
@@ -33,17 +33,17 @@ type Msg struct {
 // host provided in the url parameter.
 // Note that all the parameters of the structure
 // must have been set before calling it.
-func (c *Conn) Dial(url string) error {
+func (c *Conn) Dial(url, subprotocol string) error {
 	c.closed = true
 	c.url = url
 	c.msgQueue = []Msg{}
 	var err error
-	c.ws, err = websocket.Dial(url, "", "http://localhost/")
+	c.ws, err = websocket.Dial(url, subprotocol, "http://localhost/")
 	if err != nil {
 		return err
 	}
 	c.closed = false
-	go c.OnConnected(c.ws)
+	go c.OnConnected(c)
 
 	go func() {
 		defer c.close()
@@ -104,7 +104,7 @@ func (c *Conn) onMsg(msg []byte) {
 	}
 	// If we didn't find a propper callback we
 	// just fire the OnMessage global handler
-	go c.OnMessage(msg)
+	go c.OnMessage(msg, c)
 }
 
 func (c *Conn) close() {

--- a/evtwebsocket.go
+++ b/evtwebsocket.go
@@ -9,9 +9,9 @@ import (
 
 // Conn is the connection structure.
 type Conn struct {
-	OnMessage        func([]byte, Conn)
+	OnMessage        func([]byte, *Conn)
 	OnError          func(error)
-	OnConnected      func(Conn)
+	OnConnected      func(*Conn)
 	MatchMsg         func([]byte, []byte) bool
 	Reconnect        bool
 	PingMsg          []byte
@@ -112,7 +112,7 @@ func (c *Conn) close() {
 	c.closed = true
 	if c.Reconnect {
 		for {
-			if err := c.Dial(c.url); err == nil {
+			if err := c.Dial(c.url, ""); err == nil {
 				break
 			}
 			time.Sleep(time.Second * 1)

--- a/examples/client.go
+++ b/examples/client.go
@@ -6,20 +6,18 @@ import (
 	"time"
 
 	"github.com/rgamba/evtwebsocket"
-
-	"golang.org/x/net/websocket"
 )
 
 func main() {
 	c := evtwebsocket.Conn{
 
 		// When connection is established
-		OnConnected: func(w *websocket.Conn) {
+		OnConnected: func(w *evtwebsocket.Conn) {
 			fmt.Println("Connected")
 		},
 
 		// When a message arrives
-		OnMessage: func(msg []byte) {
+		OnMessage: func(msg []byte, w *evtwebsocket.Conn) {
 			log.Printf("Received uncatched message: %s\n", msg)
 		},
 
@@ -44,7 +42,7 @@ func main() {
 	}
 
 	// Connect
-	if err := c.Dial("ws://echo.websocket.org"); err != nil {
+	if err := c.Dial("ws://echo.websocket.org", ""); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Hi rgamba,

I really like your event driven websocket implementation for Go! Best and easiest to use library I've found for the language.

I have a few things I would like to add to your library:

1. The ability to specify a subprotocol on Dial
2. Pass the main Conn object as an argument to events in order to allow OnConnected and OnMessage to run Send(msg)

If you would like to me to make any adjustments so as to fit in more with your implementation, I would be happy to make them. Thanks for a great library!

Brett

